### PR TITLE
Add C port of an enhanced v0.2.0 algorithm.

### DIFF
--- a/fts_fuzzy_match/0.2.0/c/README.md
+++ b/fts_fuzzy_match/0.2.0/c/README.md
@@ -1,0 +1,19 @@
+# Fuzzy Match v0.2.0 C
+
+## Folder Contents
+
+- [`fts_fuzzy_match.c`](./fts_fuzzy_match.c) - Fuzzy Match 0.2.0 in C.
+- [`fts_fuzzy_match.h`](./fts_fuzzy_match.h) - Header file.
+- [`test.sh`](./test.sh) - Test launcher.
+- [`test.c`](./test.c) - Test code.
+
+## Test File
+
+To run the tests, open a shell and run:
+
+	./test.sh
+
+## License
+
+[`fts_fuzzy_match.c`](./fts_fuzzy_match.c) is licensed under the MIT License.
+All other files in this folder are in the Public Domain.

--- a/fts_fuzzy_match/0.2.0/c/fts_fuzzy_match.c
+++ b/fts_fuzzy_match/0.2.0/c/fts_fuzzy_match.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2022 Philip Jones
+ *
+ * Licensed under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+#define _GNU_SOURCE
+#include <ctype.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "fts_fuzzy_match.h"
+
+#undef MAX
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+
+static int32_t compute_score(
+		int32_t jump,
+		bool first_char,
+		const char *restrict match);
+
+static int32_t fuzzy_match_recurse(
+		const char *restrict pattern,
+		const char *restrict str,
+		int32_t score,
+		bool first_char);
+
+/*
+ * Returns score if each character in pattern is found sequentially within str.
+ * Returns INT32_MIN otherwise.
+ */
+int32_t fts_fuzzy_match(const char *restrict pattern, const char *restrict str)
+{
+	const int unmatched_letter_penalty = -1;
+	const size_t slen = strlen(str);
+	const size_t plen = strlen(pattern);
+	int32_t score = 100;
+
+	if (*pattern == '\0') {
+		return score;
+	}
+	if (slen < plen) {
+		return INT32_MIN;
+	}
+
+	/* We can already penalise any unused letters. */
+	score += unmatched_letter_penalty * (int32_t)(slen - plen);
+
+	/* Perform the match. */
+	score = fuzzy_match_recurse(pattern, str, score, true);
+
+	return score;
+}
+
+/*
+ * Recursively match the whole of pattern against str.
+ * The score parameter is the score of the previously matched character.
+ *
+ * This reaches a maximum recursion depth of strlen(pattern) + 1. However, the
+ * stack usage is small (the maximum I've seen on x86_64 is 144 bytes with
+ * gcc -O3), so this shouldn't matter unless pattern contains thousands of
+ * characters.
+ */
+int32_t fuzzy_match_recurse(
+		const char *restrict pattern,
+		const char *restrict str,
+		int32_t score,
+		bool first_char)
+{
+	if (*pattern == '\0') {
+		/* We've matched the full pattern. */
+		return score;
+	}
+
+	const char *match = str;
+	const char search[2] = { *pattern, '\0' };
+
+	int32_t best_score = INT32_MIN;
+
+	/*
+	 * Find all occurrences of the next pattern character in str, and
+	 * recurse on them.
+	 */
+	while ((match = strcasestr(match, search)) != NULL) {
+		int32_t subscore = fuzzy_match_recurse(
+				pattern + 1,
+				match + 1,
+				compute_score(match - str, first_char, match),
+				false);
+		best_score = MAX(best_score, subscore);
+		match++;
+	}
+
+	if (best_score == INT32_MIN) {
+		return INT32_MIN;
+	} else {
+		return score + best_score;
+	}
+}
+
+/*
+ * Calculate the score for a single matching letter.
+ * The scoring system is taken from fts_fuzzy_match v0.2.0 by Forrest Smith,
+ * which is licensed to the public domain.
+ *
+ * The factors affecting score are:
+ *   - Bonuses:
+ *     - If there are multiple adjacent matches.
+ *     - If a match occurs after a separator character.
+ *     - If a match is uppercase, and the previous character is lowercase.
+ *
+ *   - Penalties:
+ *     - If there are letters before the first match.
+ *     - If there are superfluous characters in str (already accounted for).
+ */
+int32_t compute_score(int32_t jump, bool first_char, const char *restrict match)
+{
+	const int adjacency_bonus = 15;
+	const int separator_bonus = 30;
+	const int camel_bonus = 30;
+	const int first_letter_bonus = 15;
+
+	const int leading_letter_penalty = -5;
+	const int max_leading_letter_penalty = -15;
+
+	int32_t score = 0;
+
+	/* Apply bonuses. */
+	if (!first_char && jump == 0) {
+		score += adjacency_bonus;
+	}
+	if (!first_char || jump > 0) {
+		if (isupper(*match) && islower(*(match - 1))) {
+			score += camel_bonus;
+		}
+		if (isalnum(*match) && !isalnum(*(match - 1))) {
+			score += separator_bonus;
+		}
+	}
+	if (first_char && jump == 0) {
+		/* Match at start of string gets separator bonus. */
+		score += first_letter_bonus;
+	}
+
+	/* Apply penalties. */
+	if (first_char) {
+		score += MAX(leading_letter_penalty * jump,
+				max_leading_letter_penalty);
+	}
+
+	return score;
+}

--- a/fts_fuzzy_match/0.2.0/c/fts_fuzzy_match.h
+++ b/fts_fuzzy_match/0.2.0/c/fts_fuzzy_match.h
@@ -1,0 +1,8 @@
+#ifndef FTS_FUZZY_MATCH_H
+#define FTS_FUZZY_MATCH_H
+
+#include <stdint.h>
+
+int32_t fts_fuzzy_match(const char *restrict pattern, const char *restrict str);
+
+#endif /* FTS_FUZZY_MATCH_H */

--- a/fts_fuzzy_match/0.2.0/c/test.c
+++ b/fts_fuzzy_match/0.2.0/c/test.c
@@ -1,0 +1,55 @@
+/* ********************************************************************
+ * fts_fuzzy_match tester, by Tristano Ajmone, public domain (CC0 1.0).
+ * Ported to C by Philip Jones.
+ * https://github.com/tajmone/fuzzy-search
+ * ********************************************************************
+ */
+#define DATASETFILE "../../../dataset/ue4_filenames.txt"
+#define RESULTSFILE "test_results.txt"
+#define PATTERN "LLL"
+#define MAXMATCH 100
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "fts_fuzzy_match.h"
+
+int main()
+{
+	errno = 0;
+	FILE *datafile = fopen(DATASETFILE, "rb");
+	if (datafile == NULL) {
+		perror("Failed to open input file");
+		exit(EXIT_FAILURE);
+	}
+
+	FILE *testfile = fopen(RESULTSFILE, "wb");
+	if (testfile == NULL) {
+		perror("Failed to open output file");
+		fclose(datafile);
+		exit(EXIT_FAILURE);
+	}
+
+	char *entry = NULL;
+	size_t n = 0;
+	char pattern[] = PATTERN;
+	int32_t score;
+	int matches = 0;
+	while(getline(&entry, &n, datafile) != -1) {
+		/* Strip newline included by getline. */
+		entry[strlen(entry) - 1] = '\0';
+		score = fts_fuzzy_match(pattern, entry);
+		if (score != INT32_MIN) {
+			fprintf(testfile, "%d|%s\n", score, entry);
+			matches++;
+			if (matches == MAXMATCH) {
+				break;
+			}
+		}
+	}
+	free(entry);
+	fclose(datafile);
+	fclose(testfile);
+	return EXIT_SUCCESS;
+}

--- a/fts_fuzzy_match/0.2.0/c/test.sh
+++ b/fts_fuzzy_match/0.2.0/c/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+cc test.c fts_fuzzy_match.c -o test || exit 1
+
+./test
+if [[ $(uname -s) == MINGW* ]]; then
+	dos2unix test_results.txt
+fi


### PR DESCRIPTION
I'm unsure if this is in scope for this repo - if not, I'll put it in its own repo and you can add it to the "Derivatives" table if you like.

This is an enhanced version of the v0.2.0 algorithm, but I still believe it fits within the goals of this repo:

- It uses the same scoring system and passes the `expected_results.txt` test.
- In my opinion, it's much neater and easier to understand than the original (~70% LOC, less than half the number of characters), so it fits with the educational theme.
- It doesn't suffer from the recursion limit, so always finds the best score (for the full ue4 filename list, this requires setting `recursionLimit` to at least 18 in the C++ version).
- Some quick tests suggest it's slightly faster than the original.

The only downside is that it's a significant enough rewrite that you might not recognise that it's doing exactly the same job as the C++ version if you were to see them side-by-side.

Edit: I've stuck it in its [own repo](https://github.com/philj56/fuzzy-match) as well, but still feel free to merge this or do whatever you see fit.